### PR TITLE
Update sdk version

### DIFF
--- a/linka-firmware.ino
+++ b/linka-firmware.ino
@@ -202,7 +202,11 @@ void loop()
   }
   else {
     // If we've lost Wifi, start captive portal, but check periodically for WiFi
+    // When updating to newer SDK, need to make sure we can store the wifi configuration
+    // https://github.com/esp8266/Arduino/pull/7902
+    WiFi.persistent(true);
     wc.startConfigurationPortal(AP_RESET);
+    WiFi.persistent(false);
   }
 
   updatePmsReadings();
@@ -499,7 +503,11 @@ void initWifi()
   // Check if we need to start captive portal
   if (!wc.autoConnect()) {
       Serial.println("\tUnable to connect to wifi, starting Configuration portal and checking periodically for wifi");
+      // When updating to newer SDK, need to make sure we can store the wifi configuration
+      // https://github.com/esp8266/Arduino/pull/7902
+      WiFi.persistent(true);
       wc.startConfigurationPortal(AP_RESET); // if not connected show the configuration portal
+      WiFi.persistent(false);
   } else {
     if (force_params_portal) {
       Serial.println("\tConfig params not found, start Params Portal");

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,7 +20,7 @@ lib_deps =
 	mrfaptastic/WiFiConnect Lite@^1.0.0
 
 [env:linka]
-platform = espressif8266@2.6.3
+platform = espressif8266@3.2.0
 board = d1_mini
 framework = arduino
 lib_deps = 


### PR DESCRIPTION
On version `3.0.0` of the SDK, they've [introduced](https://github.com/esp8266/Arduino/pull/7902) a breaking change to how the wifi starts and how new configurations get stored.

Ideally, this would be handled in the WifiConnect Library, but it hasn't been updated in a while, I'll preprare a PR for them, but for now, we can use this as a workaround.