### PR TITLE
Add option to factory reset microcontroller

### DIFF
--- a/config.h
+++ b/config.h
@@ -11,6 +11,7 @@ char sensor[8]                      = "PMS7003";
 
 /* ----------------- Hardware-specific config ---------------------- */
 #define     ESP_WAKEUP_PIN          D0               // To reset ESP8266 after deep sleep
+#define     ESP_FACTORY_RESET       D7               // To factory reset ESP8266
 #define     PMS_RX_PIN              D4               // Rx from PMS (== PMS Tx)
 #define     PMS_TX_PIN              D2               // Tx to PMS (== PMS Rx)
 #define     PMS_BAUD_RATE         9600               // PMS5003 uses 9600bps


### PR DESCRIPTION
Add option to do a factory reset of the microcontroller, which will clear the stored wifi configuration and the stored params.

This fixes #12 