### PR TITLE
Fix max character bug

### DIFF
--- a/config.h
+++ b/config.h
@@ -4,7 +4,7 @@ uint32_t    g_pms_warmup_period     = 30;               // Seconds to warm up PM
 uint32_t    g_pms_report_period     = 120;              // Seconds between reports
 char sensor[8]                      = "PMS7003";
 
-#define VERSION                 "0.3.2"
+#define VERSION                 "0.3.3"
 
 /* Serial */
 #define     SERIAL_BAUD_RATE    115200                // Speed for USB serial console

--- a/linka-firmware.ino
+++ b/linka-firmware.ino
@@ -482,8 +482,8 @@ void initWifi()
 
   // Configure custom parameters
   WiFiConnectParam api_key_param("api_key", "API Key", api_key, 33);
-  WiFiConnectParam latitude_param("latitude", "Latitude", latitude, 13);
-  WiFiConnectParam longitude_param("longitude", "Longitude", longitude, 13);
+  WiFiConnectParam latitude_param("latitude", "Latitude", latitude, 11);
+  WiFiConnectParam longitude_param("longitude", "Longitude", longitude, 11);
   WiFiConnectParam sensor_param("sensor", "Sensor model", sensor, 8);
   WiFiConnectParam description_param("description", "Description", description, 21);
   WiFiConnectParam api_url_param("api_url", "URL for the backend", api_url, 71);


### PR DESCRIPTION
Currently the captive portal allows you to enter 13 characters for latitude and longitude

This cause a weird bug where only longitude is stored and the POST fails because it doesn't have the latitude value

Also the length for these fields is set to 12
https://github.com/garyservin/linka-firmware/blob/c21e0f4de0ae3c255efbe0057ccc0864bcd70b6a/linka-firmware.ino#L112-L113

In my tests 12 chars was also buggy so 11 is the number, more than enough for our use case([see reference](https://xkcd.com/2170/))